### PR TITLE
Managed Submesh

### DIFF
--- a/bin/resources/managed_materials/managed_submesh.material
+++ b/bin/resources/managed_materials/managed_submesh.material
@@ -1,0 +1,422 @@
+import * from "managed_mats.material"
+material RoR/Submesh/Body :  RoR/Managed_Mats/Base
+{
+    receive_shadows on 
+
+    technique BaseTechnique
+    {
+        pass MainShader
+        {
+			alpha_rejection greater 125
+            diffuse 0.0 0.0 0.0 1.0
+            specular 0.1 0.1 0.1 1.0 12.5
+            emissive 0.0 0.0 0.0 1.0
+            alpha_to_coverage off
+            colour_write on
+            cull_hardware none
+            depth_check on
+            depth_func less_equal
+            depth_write on
+            light_clip_planes off
+            light_scissor off
+            lighting on
+            normalise_normals on
+            polygon_mode solid
+            //scene_blend one zero
+            //scene_blend_op add
+			scene_blend alpha_blend
+            shading gouraud
+            texture_unit diffuse
+            {
+                texture_alias diffuse
+                tex_address_mode wrap
+                scale 1.0 1.0
+                colour_op alpha_blend
+            }
+        }
+
+		pass emissive
+		{
+			diffuse 1.0 1.0 1.0 1.0
+			emissive 0.25 0.25 0.25 1.0
+			ambient 1.0 1.0 1.0 1.0
+			scene_blend alpha_blend
+			depth_check on
+			depth_func less_equal
+			depth_bias 12
+            depth_write on
+			alpha_rejection greater 1
+			texture_unit emissive
+			{
+				texture_alias emissive
+			}
+		}
+
+		pass BaseRender
+		{
+			//Ambient, diffuse, emissive stuff here
+			scene_blend modulate
+			cull_hardware none
+			ambient 1 1 1 1
+			diffuse 1 1 1 1 
+			lighting on
+			
+			alpha_rejection greater 250
+ 
+			texture_unit Diffuse_Map
+			{
+				texture_alias Lighting
+			}
+		}
+		pass Reflections
+		{
+			scene_blend add
+			alpha_rejection greater 1
+			specular 0.05 0.05 0.05 0.1 0.5
+            diffuse 0.0 0.0 0.0 0.50
+			ambient 0.0 0.0 0.0 0.0
+			lighting on
+			depth_check on
+            depth_func less_equal
+			depth_bias 0
+            depth_write off
+			cull_hardware clockwise
+			cull_software back
+			transparent_sorting on
+			texture_unit diffuse
+			{
+				texture_alias reflective
+				// use alpha from this texture
+				alpha_op_ex source1 src_texture src_texture
+				// and colour from last pass
+				colour_op_ex source2 src_texture src_texture
+			}
+			texture_unit envmap
+			{
+				cubic_texture EnvironmentTexture combinedUVW
+				tex_address_mode wrap
+                scale 1 1
+				env_map cubic_reflection
+
+				tex_coord_set 0
+				// alpha blend colour with colour from last pass
+				colour_op_ex modulate src_texture src_current 1
+            }
+		}
+    }
+}
+material RoR/Submesh/Body/Alpha :  RoR/Managed_Mats/Base
+{
+    receive_shadows on 
+
+    technique BaseTechnique
+    {
+        pass MainShader
+        {
+			alpha_rejection greater 125
+            diffuse 0.0 0.0 0.0 1.0
+            specular 0.1 0.1 0.1 1.0 12.5
+            emissive 0.0 0.0 0.0 1.0
+            alpha_to_coverage off
+            colour_write on
+            cull_hardware none
+            depth_check on
+            depth_func less_equal
+            depth_write on
+            light_clip_planes off
+            light_scissor off
+            lighting on
+            normalise_normals on
+            polygon_mode solid
+            //scene_blend one zero
+            //scene_blend_op add
+			scene_blend alpha_blend
+            shading gouraud
+            texture_unit diffuse
+            {
+                texture_alias diffuse
+                tex_address_mode wrap
+                scale 1.0 1.0
+                colour_op alpha_blend
+            }
+        }
+
+		pass emissive
+		{
+			diffuse 1.0 1.0 1.0 1.0
+			emissive 0.25 0.25 0.25 1.0
+			ambient 1.0 1.0 1.0 1.0
+			scene_blend alpha_blend
+			depth_check on
+			depth_func less_equal
+			depth_bias 12
+            depth_write on
+			alpha_rejection greater 1
+			texture_unit emissive
+			{
+				texture_alias emissive
+			}
+		}
+
+		pass BaseRender
+		{
+			//Ambient, diffuse, emissive stuff here
+			scene_blend modulate
+			cull_hardware none
+			ambient 1 1 1 1
+			diffuse 1 1 1 1 
+			lighting on
+			
+			alpha_rejection greater 250
+ 
+			texture_unit Diffuse_Map
+			{
+				texture_alias Lighting
+			}
+		}
+		pass Metallic
+		{
+			scene_blend alpha_blend
+			alpha_rejection greater 1
+			specular 0.0 0.0 0.0 1.0 0.5
+            diffuse 0.0 0.0 0.0 0.50
+			lighting on
+			alpha_to_coverage on
+			shading gouraud
+			depth_check on
+            depth_func equal
+            depth_write on
+			cull_hardware clockwise
+			texture_unit diffuse
+			{
+				texture_alias reflective
+				// use alpha from this texture
+				alpha_op_ex source1 src_texture src_texture
+				// and colour from last pass
+				colour_op_ex source2 src_texture src_texture
+			}
+
+			texture_unit envmap
+			{
+				cubic_texture EnvironmentTexture combinedUVW
+				color_op_ex blend_manual src_texture src_current 0.5
+				tex_address_mode wrap
+                scale 1 1
+				env_map cubic_reflection
+
+				tex_coord_set 0
+				// alpha blend colour with colour from last pass
+				colour_op_ex blend_diffuse_alpha src_texture src_current
+            }
+		}
+    }
+}
+material RoR/Submesh/Wheels:  RoR/Managed_Mats/Base
+{
+    receive_shadows on 
+
+    technique BaseTechnique
+    {
+        pass MainShader
+        {
+			alpha_rejection greater 1
+            diffuse 0.0 0.0 0.0 1.0
+            specular 0.1 0.1 0.1 1.0 12.5
+            emissive 0.0 0.0 0.0 1.0
+            alpha_to_coverage off
+            colour_write on
+            cull_hardware none
+            depth_check on
+            depth_func less_equal
+            depth_write on
+            light_clip_planes off
+            light_scissor off
+            lighting on
+            normalise_normals on
+            polygon_mode solid
+            //scene_blend one zero
+            //scene_blend_op add
+			scene_blend alpha_blend
+            shading gouraud
+            texture_unit diffuse
+            {
+                texture_alias diffuse
+                tex_address_mode wrap
+                scale 1.0 1.0
+                colour_op alpha_blend
+            }
+        }
+
+		pass fake
+		{
+			diffuse 0.0 0.0 0.0 0.0
+			scene_blend alpha_blend
+		}
+
+		pass BaseRender
+		{
+			//Ambient, diffuse, emissive stuff here
+			scene_blend modulate
+			ambient 1 1 1 1
+			diffuse 1 1 1 1 
+			lighting on
+			
+			alpha_rejection greater 1
+ 
+			texture_unit Diffuse_Map
+			{
+				texture_alias Lighting
+			}
+		}
+		pass Reflections
+		{
+			scene_blend add
+			alpha_rejection greater 1
+			specular 0.05 0.05 0.05 0.1 0.5
+            diffuse 0.0 0.0 0.0 0.50
+			ambient 0.0 0.0 0.0 0.0
+			lighting on
+			depth_check on
+            depth_func less_equal
+			depth_bias 0
+            depth_write off
+			cull_hardware clockwise
+			cull_software back
+			transparent_sorting on
+			texture_unit diffuse
+			{
+				texture_alias reflective
+				// use alpha from this texture
+				alpha_op_ex source1 src_texture src_texture
+				// and colour from last pass
+				colour_op_ex source2 src_texture src_texture
+			}
+			texture_unit envmap
+			{
+				cubic_texture EnvironmentTexture combinedUVW
+				tex_address_mode wrap
+                scale 1 1
+				env_map cubic_reflection
+
+				tex_coord_set 0
+				// alpha blend colour with colour from last pass
+				colour_op_ex modulate src_texture src_current 1
+            }
+		}
+		pass Lighting2
+		{
+			alpha_rejection greater 128
+			diffuse 1.0 1.0 1.0 0.5
+			lighting on
+			shading phong
+			scene_blend one zero
+			scene_blend modulate
+			cull_hardware clockwise
+		}
+    }
+}
+
+material RoR/Submesh/Wheels/Alpha :  RoR/Managed_Mats/Base
+{
+    receive_shadows on 
+
+    technique BaseTechnique
+    {
+        pass MainShader
+        {
+			alpha_rejection greater 1
+            diffuse 0.0 0.0 0.0 1.0
+            specular 0.1 0.1 0.1 1.0 12.5
+            emissive 0.0 0.0 0.0 1.0
+            alpha_to_coverage off
+            colour_write on
+            cull_hardware none
+            depth_check on
+            depth_func less_equal
+            depth_write on
+            light_clip_planes off
+            light_scissor off
+            lighting on
+            normalise_normals on
+            polygon_mode solid
+            //scene_blend one zero
+            //scene_blend_op add
+			scene_blend alpha_blend
+            shading gouraud
+            texture_unit diffuse
+            {
+                texture_alias diffuse
+                tex_address_mode wrap
+                scale 1.0 1.0
+                colour_op alpha_blend
+            }
+        }
+
+		pass fake
+		{
+			diffuse 0.0 0.0 0.0 0.0
+			scene_blend alpha_blend
+		}
+
+		pass BaseRender
+		{
+			//Ambient, diffuse, emissive stuff here
+			scene_blend modulate
+			ambient 1 1 1 1
+			diffuse 1 1 1 1 
+			lighting on
+			
+			alpha_rejection greater 1
+ 
+			texture_unit Diffuse_Map
+			{
+				texture_alias Lighting
+			}
+		}
+		pass Metallic
+		{
+			scene_blend alpha_blend
+			alpha_rejection greater 1
+			specular 0.0 0.0 0.0 1.0 0.5
+            diffuse 0.0 0.0 0.0 0.50
+			lighting on
+			alpha_to_coverage on
+			shading gouraud
+			depth_check on
+            depth_func equal
+            depth_write on
+			cull_hardware clockwise
+			texture_unit diffuse
+			{
+				texture_alias reflective
+				// use alpha from this texture
+				alpha_op_ex source1 src_texture src_texture
+				// and colour from last pass
+				colour_op_ex source2 src_texture src_texture
+			}
+
+			texture_unit envmap
+			{
+				cubic_texture EnvironmentTexture combinedUVW
+				color_op_ex blend_manual src_texture src_current 0.5
+				tex_address_mode wrap
+                scale 1 1
+				env_map cubic_reflection
+
+				tex_coord_set 0
+				// alpha blend colour with colour from last pass
+				colour_op_ex blend_diffuse_alpha src_texture src_current
+            }
+		}
+		pass Lighting2
+		{
+			alpha_rejection greater 128
+			diffuse 1.0 1.0 1.0 0.5
+			lighting on
+			shading phong
+			scene_blend one zero
+			scene_blend modulate
+			cull_hardware clockwise
+		}
+    }
+}

--- a/bin/resources/managed_materials/managed_submesh.material
+++ b/bin/resources/managed_materials/managed_submesh.material
@@ -1,4 +1,6 @@
 import * from "managed_mats.material"
+
+//author: derbymutt (Alexander Scheiner)
 material RoR/Submesh/Body :  RoR/Managed_Mats/Base
 {
     receive_shadows on 


### PR DESCRIPTION
The user will use in their material file:

```
import * from "managed_submesh.material"

//for the body of the submesh truck
material body : material RoR/Submesh/Body
{
    //diffuse texture
    set_texture_alias diffuse       image.dds
    //toggles on with headlights
    set_texture_alias emissive      image.dds
    //reflective, based on type of material, can either be alpha based or grayscale
    set_texture_alias reflective    image.dds
    //prelighting or a/o, can be white to have none
    set_texture_alias Lighting      image.dds
}

//for the wheels of the truck
material wheel : material RoR/Submesh/Wheels/Alpha
{
    //diffuse texture
    set_texture_alias diffuse       image.dds
    //reflective, based on type of material, can either be alpha based or grayscale
    set_texture_alias reflective    image.dds
    //prelighting or a/o, can be white to have none
    set_texture_alias Lighting      image.dds
}
```

Adding /Alpha to the end of the referenced material will change the reflection from based on grayscale to based on alpha. The materials have been stripped down to the minimum number of passes required for user friendliness.

This supports PSSM shadows, reflections, toggle-able light sources, and pre-lighting (a/o).

![9k294n6 1](https://cloud.githubusercontent.com/assets/12500108/15457513/ad856e94-2058-11e6-8ad6-a96234cdaf11.jpg)
